### PR TITLE
Improve HTTP error usability

### DIFF
--- a/lib/swiftner.rb
+++ b/lib/swiftner.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative "swiftner/error"
 require_relative "swiftner/API/service"
 require_relative "swiftner/API/space"
 require_relative "swiftner/API/transcription"
@@ -12,12 +13,6 @@ require_relative "swiftner/version"
 
 ### Swiftner
 module Swiftner
-  class Error < StandardError; end
-  class Forbidden < Error; end
-  class Unauthorized < Error; end
-  class NotFound < Error; end
-  class InternalError < Error; end
-
   class << self
     attr_accessor :configuration
   end

--- a/lib/swiftner/client.rb
+++ b/lib/swiftner/client.rb
@@ -30,11 +30,11 @@ module Swiftner
     def handle_response(response)
       case response.code
       when 200 then response
-      when 401 then raise Unauthorized
-      when 403 then raise Forbidden
-      when 404 then raise NotFound
-      when 500 then raise InternalError
-      else raise Error, "Unknown error occurred"
+      when 401 then raise Unauthorized.from_response(response)
+      when 403 then raise Forbidden.from_response(response)
+      when 404 then raise NotFound.from_response(response)
+      when 500 then raise InternalError.from_response(response)
+      else raise Error.new("Unknown error occurred", response: response)
       end
     end
   end

--- a/lib/swiftner/error.rb
+++ b/lib/swiftner/error.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Swiftner
+  # Encapsulates all errors that can be raised by the Swiftner API
+  class Error < StandardError
+    attr_reader :response
+
+    def self.from_response(response)
+      return new(response["detail"], response: response) if response.key?("detail")
+
+      new(response.to_s, response: response)
+    end
+
+    def initialize(message, response: nil)
+      @response = response
+      super(message)
+    end
+  end
+
+  class Forbidden < Error; end
+  class Unauthorized < Error; end
+  class NotFound < Error; end
+  class InternalError < Error; end
+end

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -3,6 +3,22 @@
 require "test_helper"
 
 class ErrorsTest < Minitest::Test
+  def test_creating_error_from_response_with_detail
+    response = { "detail" => "You are not authorized" }
+    error = Swiftner::Error.from_response(response)
+
+    assert_equal "You are not authorized", error.message
+    assert_equal response, error.response
+  end
+
+  def test_creating_error_from_response_without_detail
+    response = { "err" => "a" }
+    error = Swiftner::Error.from_response(response)
+
+    assert_equal "{\"err\"=>\"a\"}", error.message
+    assert_equal response, error.response
+  end
+
   def test_error_inheritance
     assert Swiftner::Error < StandardError
   end


### PR DESCRIPTION
The original solution hides a lot of useful information from the end user. This proposition improves both the developer experience (providing more feedback during development) and integration with external tools (like Honeybadger, DataDog etc) making errors with the same HTTP code, but different causes easier to group.

If this passes internal review, will forward the PR to the vendor for further feedback.